### PR TITLE
Vaultwarden setup

### DIFF
--- a/hosts/goldberg/configuration.nix
+++ b/hosts/goldberg/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-config.nix
     ../../services/mumble.nix
     ../../services/website.nix
+    ../../services/vaultwarden.nix
   ];
 
   system.stateVersion = "23.05";

--- a/hosts/shirley/configuration.nix
+++ b/hosts/shirley/configuration.nix
@@ -5,6 +5,7 @@
     ./hardware-config.nix
     ../../services/mumble.nix
     ../../services/website.nix
+    ../../services/vaultwarden.nix
   ];
 
   system.stateVersion = "23.05";

--- a/secrets/all/secrets.yaml
+++ b/secrets/all/secrets.yaml
@@ -1,5 +1,9 @@
 #ENC[AES256_GCM,data:yZuJDeNL04htjQK/wCi7tDFzkeurKNWtMcX3YO4ZTIjksZBDMG7/mvAEuVeL5ffWa+faIs/uM1cATaRm4JVDCai5fWR7S2//TRUHAhkDbSYIZHDjFUFGqpWd8T7WVT53TPtX,iv:n1zrjd/QCFNXfYbnaeZviUfeDq+x0Z8skkkcS/dP86o=,tag:2sn+f3m2PH3BIKt4qrqVSw==,type:comment]
 root_user_password: ENC[AES256_GCM,data:hzwnpYfDNN46Hahf8Vlr01AotR6zuUDqFz/z/XxWx+i3G1p4j03stuKmB//wQSF45T8b+Iuh7PMOrCgwwtRyJVVYnm4q2m2xin+pHQ+/ecr5NgNx6XzsU03DtLLORTCzV4XE4DcMZHQA1g==,iv:bN3hgWYiGGkSIyixZdEt8q41GINlIeO/c/Z0CcAzFik=,tag:Y7xf5NQcvfJaoWYbx88eeA==,type:str]
+mail:
+    smtp_user: ENC[AES256_GCM,data:4/tY1GRD0FuJP+R5tDhEoA==,iv:ByE2qie8s1UhYfUoyT1mizJdTelri+jBuxXIdVz65IE=,tag:4TOWZPB0bwJ3jJTAQl5pgA==,type:str]
+    smtp_pass: ENC[AES256_GCM,data:c/P1B/OPi8T0ViL4xS62K0wobEa/Xw2OHfVV7clNZyxXIYjXddxKBO2elxGHDlL8UclKgPo=,iv:seVlE/F7313v1R1v4k6zVzCc20SSaYAWLwVnMDWwFhA=,tag:mLHfBlWmmjKgiYm4ZA0+CQ==,type:str]
+    smtp_host: ENC[AES256_GCM,data:6goxZg5vqCihchZq68zuBA==,iv:ZXeM5RHda81av+jL5by6isYaU9WwdfYsI7RxG99NMwE=,tag:nAHpzt2oekZcOyPEO4nwRQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -24,8 +28,8 @@ sops:
             UXludFJ5UDEvN2pHMEQweWIvN0NYaFEKB7lVKrsB3eX77iKWwFAXp7LVl+fPcGOl
             8CkIBa/rkSWMe0xIetew60wIwx2ZVAv5TTDmKIZyQSTayOpbG3zcdg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-11-27T21:53:46Z"
-    mac: ENC[AES256_GCM,data:8rzaM8lDGLwwMbgcqaB3zj73l3mV0OFeshrHGRVw+akk9ipz0WKnhKHPGbGcaktWd61cg52/F2Fz573PWHthqoI/v0NJc7bpOKG3HreKyJyJ5AbZ+eFYrSLSNKaOXvKmwWHRMnFASOd97QaSYxQaHCDhQObf0XBXEnRktX9NtXs=,iv:j5E/YS1yI/Tgqq9Dio/b7EKrPwcJFBnVDtry91suym0=,tag:Hev9lYgsMxKFxcfozX+VdA==,type:str]
+    lastmodified: "2022-12-23T21:12:29Z"
+    mac: ENC[AES256_GCM,data:5BwRMg8GTjWrxR9g0z6qvni2CnJp8yWngPv0izmWu5+zUEZDj8fsUTr2kMutWwac/AY9Q2o8CRgescGApdr/F+kKXYP83dqS9Ka8MaCVMqenNH97PfXh+kMcsKYdYqIGzi2i1PmTDTmowsPZ8kecEVwZXOqKug2NhT+YWy+cZvQ=,iv:4xxHX0qrt4bSo0M2MEfd3X+XgTVkAGuhdLGopbWY/hQ=,tag:RhVR9qitWecMiH0NCilyJQ==,type:str]
     pgp:
         - created_at: "2022-12-23T19:08:38Z"
           enc: |

--- a/secrets/goldberg/secrets.yaml
+++ b/secrets/goldberg/secrets.yaml
@@ -5,6 +5,8 @@ synapse:
 murmur:
     #ENC[AES256_GCM,data:ionYo3rz6G1ZhOmwBDleXPO7/reeF6tpgA==,iv:4iQ1FYTvxyyNaQDPxHErV0fevsnU5p55wT27nOwMStM=,tag:ynCgbQsvX5ow4+vc2Qz8MQ==,type:comment]
     registry_password: ""
+vaultwarden:
+    env: ENC[AES256_GCM,data:mDqHHAjisl0din/q67+zH7NMKLXld9qC0Si6ZREhRStXr6HEFD/QwaGLN86AvUI7sHNf9l4nrgKOht7uXNJrkjuidGsFEEJWkuUOjBRnrtipNKV2YK7giPQXEhH7wTdGeaqxqi4sk90Oq/FoKi2vPkFyNWGOQ5vOXkKKXjjHnbyKIQkIRWya2Dy6IN0CXU8UK0OiQXY3kgEFOyJoqt4sx/HOScHNKkaLb8U+0rpfzxSVyP3oY4o/DFkE51bnd/CNKg3ZK4Ynp/5m7Rs=,iv:aWpDXSp6Ds7cfdw/vfM3I5wcHz0MytnhpIIWEa24LBE=,tag:5YZKo4ZCT57gji8iyBMAiQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -20,8 +22,8 @@ sops:
             U1lPUWh4WGlTYWdUb0dlNXZaSk9JWU0Kk5CxVOkZO17h0dYifV9s8g7LujLHcE9G
             /iSC7EVUx+9cbOUiJf6dcomT+np7CHmhfOykPhm4tzrauaTuPEekew==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-12-11T17:36:25Z"
-    mac: ENC[AES256_GCM,data:nHBfQwFab4cpH9rtHlrnkCbwpqza4E7IZ70t8kxlNEc4iY5lSZczp83M36Lyf49OHzOlzFnCdtwNu7ACNfD238O8d1QXA/zW00AdtMUETJqJS9YA6OXzoXErocdJ0WPiCwDx0WMfzV7cj+W3nmVTZWDp75uWHM1KXidGrgh6+zc=,iv:bHZMMZe4D5rPjRD60cw5FohfCRYYle2gaDceWlCZ4yI=,tag:AOv+5KZWxM3U8jyvtyJOvg==,type:str]
+    lastmodified: "2022-12-23T23:25:37Z"
+    mac: ENC[AES256_GCM,data:PRTipNdDCYH1b3G/6tuZi3wbp22xwpBTzUxAf+mH9w3/IiLFgs2Wcrr5sNhS3HR6pXL5QBihTlZt2j+2sImFHtxsUSKOzxwSqq5brmY+W1CNxoveXWIWmwhYzrW1MMO8Vhyjgc69dvGPKNGR513XIpo7dUtWcwFh6ZwtQ4WDdkA=,iv:rlgHNkegTWjV6KJ9JJGZVG+8wy7yzT4ZZ1kF8bp7nZM=,tag:PgHGS17TRmWGT4wJ5shT/g==,type:str]
     pgp:
         - created_at: "2022-12-23T19:08:40Z"
           enc: |

--- a/secrets/shirley/secrets.yaml
+++ b/secrets/shirley/secrets.yaml
@@ -1,5 +1,7 @@
 murmur:
     registry_password: ENC[AES256_GCM,data:jgMmirQNhwTQZMyfbbbJku9JDqxtuKepIIpbiloX0qnUnytu1vvjFkGZH5dag/e/EDHszqkALNlUZz7wdlxZn3QDDlv0rQITJtsp,iv:aLIPiHDGC4vNXfNgqR852/jbChv2uu5q0Yy9I4ej5ts=,tag:cy4rs+YCglNKEaq+3arfow==,type:str]
+vaultwarden:
+    env: ENC[AES256_GCM,data:4zeSpiaJQ8v00EBHrS6IU/1KXCEP6EBpkMacW0mf3ygZxSfUL3oQ11sXOu24OOMnTpaZUPJ68rj1jSNgBoVQ7rLttpCHKy62ART2xi0PcSCpDCBLpBocPdpFydQzwFOrMAYpcS6SB/ijy2ZxvfzVQqykcqfLdwdZs3PCys15OSQT269FmFERT25pTW7d6zxE3eY2YhLf1Y+6MjYHffAEv8RqN35UWyAOh8dJU09lbEsUiBRwN3tNhQ0STOsShhxY/ogMZdAHQwvGjo0=,iv:yK9PBOURtOVBBPwuJSpARvb5eXUIhPypEbEYbX2PqRs=,tag:MG7fcBPMg9eMjtD5V+yjBw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -15,8 +17,8 @@ sops:
             YmRyblR5NkhkTXc2MlhlcWtYSUV0S0kKk1lgI+wDwPUCTOWEBnMzSlrHwNNaB3/D
             ykos0itANTZjLcawhrOX/p8qBR2NUJ0U8On5Pls16UMxfgAkdJtkcA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2022-11-26T23:55:22Z"
-    mac: ENC[AES256_GCM,data:ec3JBflxNEo9aHsben5oXb4FlCZzNGh6u6Xc+oa1TFL6rpL2qmOErT8RMkvzij49cz2hLEHMWbiD12fPO2sU/ZHjck7G+dvyRphavEsflzRmLWMj8k7SZR6e/UZIhwcBx15uQndbKhTTSH5EMtiH3Kq+HDNPgAtG6fFQLjNJWk8=,iv:3Od/41rv8YOXdq6uNUcRUtEdFuO4HL9xAtcGRrw6OQ4=,tag:JpVVVveJZfLQteBOOFndCg==,type:str]
+    lastmodified: "2022-12-24T00:41:40Z"
+    mac: ENC[AES256_GCM,data:NpAPmNxkz631OrUVVvjOjKQDiBFV4BuvsWQkz+IlHqDOyTBiRoKdLyKTAengMxcdelJdbJngt9PQ/8qbJwvAszuvM4WgagCiD9tjEmqXUtuFjqdpgUaOvYol7+ba7XvVOoVny0IEWUA0u0g2U1HZHiDf+xO2r3RYxD+SloaUOLk=,iv:u3P0mbce7JPMaNBbCRQXx0DDDX6zw84SmiI7wDN+KVQ=,tag:5vdlp4Cf63N34OE3l0xq8A==,type:str]
     pgp:
         - created_at: "2022-12-23T19:08:27Z"
           enc: |

--- a/services/vaultwarden.nix
+++ b/services/vaultwarden.nix
@@ -1,0 +1,66 @@
+{ lib, config, pkgs, baseDomain, ... }:
+
+let
+  vwDbUser = config.users.users.vaultwarden.name;
+  vwDbName = config.users.users.vaultwarden.name;
+  isDev = (builtins.substring 0 3 baseDomain) == "dev";
+  isDevStr = lib.optionalString isDev;
+in {
+  sops.secrets = {
+    "vaultwarden/env" = {};
+  };
+
+  services.nginx.virtualHosts."passwords.${baseDomain}" = {
+    enableACME = true;
+    forceSSL = true;
+    locations."/".proxyPass = "http://127.0.0.1:${builtins.toString config.services.vaultwarden.config.ROCKET_PORT}";
+  };
+
+  services.postgresql = {
+    enable = true;
+    ensureDatabases = [ vwDbName ];
+    ensureUsers = [{
+      name = vwDbUser;
+      ensurePermissions = {
+        "DATABASE ${vwDbName}" = "ALL PRIVILEGES";
+      };
+    }];
+  };
+
+  services.vaultwarden = {
+    enable = true;
+    dbBackend = "postgresql";
+    environmentFile = config.sops.secrets."vaultwarden/env".path;
+    config = let
+      name = "${isDevStr "[dev] "}chaos.jetzt Vaultwarden";
+    in {
+      # NOTE (@e1mo): I would _realy_ like to disable E-Mail based 2FA
+      # _ENABLE_EMAIL_2FA = false;
+      DATABASE_URL = "postgresql:///${vwDbName}";
+      DOMAIN = "https://passwords.${baseDomain}";
+      EVENTS_DAYS_RETAIN = 60;
+      # Do we want to keep an event log of who viewed whihc password when?
+      # See <https://bitwarden.com/de-DE/help/event-logs/> for reference
+      EXTENDED_LOGGING = true;
+      HELO_NAME = config.networking.fqdn;
+      ICON_BLACKLIST_NON_GLOBAL_IPS = true;
+      INCOMPLETE_2FA_TIME_LIMIT = 5;
+      INVITATION_ORG_NAME = name;
+      INVITATIONS_ALLOWED = true;
+      LOG_LEVEL = if isDev then "info" else "warn";
+      ORG_EVENTS_ENABLED = false;
+      PASSWORD_HINTS_ALLOWED = false;
+      ROCKET_ADDRESS = "127.0.0.1"; # Binding to a unix socket (or at least IPv6 _and_ IPv4) would be desirable but is not yet supported in Rocket
+      ROCKET_PORT = 8222;
+      SIGNUPS_ALLOWED = false;
+      SMTP_FROM = "vaultwarden${isDevStr "-dev"}@chaos.jetzt";
+      SMTP_FROM_NAME = "${name} Vaultwarden";
+      SMTP_SECURITY = "force_tls";
+      USE_SYSLOG = true;
+    };
+  };
+
+  systemd.services.vaultwarden = {
+    after = [ "postgresql.service" ];
+  };
+}


### PR DESCRIPTION
I decoded on the somewhat unordered looking isDev thing in order to clearly indicate the seperation between the dev and production setup in E-Mails for security reasons.

I decided to leave registrations disabled since this will be a fairly focused instance for own needs and I am not sure if we should take on the responsibility of hosting individuals private passwords. For people to access the (to be created) chaos.jetzt org, we need to invite them from the WebUI.

Dev setup is running under <https://passwords.dev.chaos.jetzt>. I can give access to test functionality if wanted prior to approval. 