### PR TITLE
nix flake update

### DIFF
--- a/.github/workflows/build-systems.yaml
+++ b/.github/workflows/build-systems.yaml
@@ -21,7 +21,7 @@ jobs:
     if: needs.avoid_duplicates.outputs.should_skip != 'true'
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v19
+    - uses: cachix/install-nix-action@v20
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: cachix/cachix-action@v12

--- a/.github/workflows/build-systems.yaml
+++ b/.github/workflows/build-systems.yaml
@@ -24,10 +24,10 @@ jobs:
     - uses: cachix/install-nix-action@v20
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - uses: cachix/cachix-action@v12
-      with:
-        name: chaos-jetzt-nixfiles
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    #- uses: cachix/cachix-action@v12
+    #  with:
+    #    name: chaos-jetzt-nixfiles
+    #    authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: nix flake check
       run: |
         nix flake check --no-build
@@ -47,7 +47,8 @@ jobs:
           echo "::group::Building ${host}"
           drv=".#nixosConfigurations.$host.config.system.build.toplevel"
           build_cmd="nix build ${drv}"
-          cachix watch-exec chaos-jetzt-nixfiles -- $build_cmd
+          #cachix watch-exec chaos-jetzt-nixfiles -- $build_cmd
+          $build_cmd
           echo "::endgroup::"
           out_path=$($build_cmd --print-out-paths)
           echo -e "\x1b[32;1mSuccessfully built .#nixosConfigurations.${host}\x1b[0m"

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -16,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675763311,
-        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
+        "lastModified": 1681217261,
+        "narHash": "sha256-RbxCHWN3Vhyv/WEsXcJlDwF7bpvZ9NxDjfSouQxXEKo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
+        "rev": "3fb8eedc450286d5092e4953118212fa21091b3b",
         "type": "github"
       },
       "original": {
@@ -32,11 +35,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1675556398,
-        "narHash": "sha256-5Gf5KlmFXfIGVQb2hmiiE7FQHoLd4UtEhIolLQvNB/A=",
+        "lastModified": 1681005198,
+        "narHash": "sha256-5LrnBeXR7Hv8OXh6eany7br4qBW+ZNl4LKf1CJu9zbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e32c33811815ca4a535a16faf1c83eeb4493145b",
+        "rev": "e45cc0138829ad86e7ff17a76acf2d05e781e30a",
         "type": "github"
       },
       "original": {
@@ -61,16 +64,31 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1675872570,
-        "narHash": "sha256-RPH3CeTv7ixC2WcYiKyhmIgoH/9tur4Kr+3Vg/pleQk=",
+        "lastModified": 1681209176,
+        "narHash": "sha256-wyQokPpkNZnsl/bVf8m1428tfA0hJ0w/qexq4EizhTc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "8fec29b009c19538e68d5d814ec74e04f662fbd1",
+        "rev": "00d5fd73756d424de5263b92235563bc06f2c6e1",
         "type": "github"
       },
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }


### PR DESCRIPTION
Routine update of our nixpkgs version, also updated nix-install-action for the ci due to incompatibilities with newer nix versions.

Also disabled the cachix integration (07779e1) since the free open-source tier is either not applicable to us or not automatically activated for us. With how rare PRs are for us, I think it's fine to use our 2.000/3.000 (?) free hours for building until we get this sorted out.