### PR TITLE
services/website: Deliver alternative image formats + custom 404

### DIFF
--- a/services/website.nix
+++ b/services/website.nix
@@ -41,6 +41,10 @@ in {
       serverAliases = [ "www.${baseDomain}" ];
       root = webroot;
       locations = {
+        # A ?version= is appeneded to the font files, so we can be quite liberal
+        "/theme/fonts/open-sans/fonts/".extraConfig = ''
+          expires 1M;
+        '';
         "/".extraConfig = ''
           log_not_found off;
           error_page 404 /404.html;

--- a/services/website.nix
+++ b/services/website.nix
@@ -41,6 +41,10 @@ in {
       serverAliases = [ "www.${baseDomain}" ];
       root = webroot;
       locations = {
+        "/".extraConfig = ''
+          log_not_found off;
+          error_page 404 /404.html;
+        '';
         "~* ^(/images/.+)\\.(png|jpe?g)$".extraConfig = ''
           set $base $1;
           add_header Vary Accept;


### PR DESCRIPTION
Deliver images in alternative formats (453f72a): If the browser supports webp/avif images, nginx checks if any file with the same name but the other formats extension is available.
PR for the Website: https://github.com/chaos-jetzt/website_pelican/pull/26

Support custom 404 page (972cfda): The actual 404 will be generated from pelican. log_not_found was set for privacy reasons (since we don't have a favicon, every request still gets logged with it's full IP due to the 404)
PR for the Website: https://github.com/chaos-jetzt/website_pelican/pull/27

