### PR TITLE
website: Clear old generations on dev

### DIFF
--- a/services/website.nix
+++ b/services/website.nix
@@ -82,4 +82,14 @@ in {
       chown -R web-deploy:${config.services.nginx.group} ${webroot}
     fi
   '';
+
+  # Delete dev website builds older than 28 days
+  systemd.services."website-purge-old" = lib.mkIf isDev {
+    path = with pkgs; [ fd ];
+    script = ''
+      fd --print0 --changed-before 28d --type d --max-depth 1 --min-depth 1 . ${webroot} --exec-batch rm -vr {} \;
+    '';
+    startAt = "weekly";
+    serviceConfig.User = "web-deploy";
+  };
 }


### PR DESCRIPTION
With https://github.com/chaos-jetzt/website_pelican/pull/33, a lot of orphans are to be expected which will take up space on our servers. This introduces a timer which runs once a week and will delete any website generations older than 28 days.