### PR TITLE
Add tickets.chaos.jetzt redirect

### DIFF
--- a/services/website.nix
+++ b/services/website.nix
@@ -59,6 +59,12 @@ in {
         "/.well-known/matrix/".alias =  matrixWellKnownDir + "/";
       };
     };
+
+    virtualHosts."tickets.${baseDomain}" = {
+      enableACME = true;
+      forceSSL = true;
+      locations."/".return = "307 https://tickets.chaostreff-flensburg.de/chaos.jetzt$request_uri";
+    };
   };
 
   users.users."web-deploy" = {


### PR DESCRIPTION
With all https://tickets.chaos.jetzt/shortcode links will redirect to the appropriate ticket-shop without a need for us to place manual redirect links.