### PR TITLE
services/synapse: Init sliding sync

### DIFF
--- a/secrets/goldberg/secrets.yaml
+++ b/secrets/goldberg/secrets.yaml
@@ -11,6 +11,7 @@ dokuwiki:
 vaultwarden:
     env: ENC[AES256_GCM,data:mDqHHAjisl0din/q67+zH7NMKLXld9qC0Si6ZREhRStXr6HEFD/QwaGLN86AvUI7sHNf9l4nrgKOht7uXNJrkjuidGsFEEJWkuUOjBRnrtipNKV2YK7giPQXEhH7wTdGeaqxqi4sk90Oq/FoKi2vPkFyNWGOQ5vOXkKKXjjHnbyKIQkIRWya2Dy6IN0CXU8UK0OiQXY3kgEFOyJoqt4sx/HOScHNKkaLb8U+0rpfzxSVyP3oY4o/DFkE51bnd/CNKg3ZK4Ynp/5m7Rs=,iv:aWpDXSp6Ds7cfdw/vfM3I5wcHz0MytnhpIIWEa24LBE=,tag:5YZKo4ZCT57gji8iyBMAiQ==,type:str]
 hedgedoc_env: ENC[AES256_GCM,data:VHIzmq7P1pqS72HbRXRT3k7n6vyPkzkQFJdveseCAHnzdXlEF0lHr+Up7J6XhfhtQXO3ogV2jkGZpOMY0OuEvhLf2yGkBj3W0ZtG7Kx6Rdcbb5rG7Z6Vb1vpL/aT88QFd3VX23M+FPFyWeYKGOvGRuCela+mUX7jDs2W4jOrYOtEGe3+V08DcvtcCvE2L1NqeDQ=,iv:011/ZRdQlkFQ2TZpzQhfRf/OTawnHFQDockLGlOrkmc=,tag:Y66RIBtyjl5VSo23GU4sNg==,type:str]
+sliding-sync-env: ENC[AES256_GCM,data:TfWu/SaDaTGAkBgD9NjFPIuQI3U+Gkcd7SOYPkgBX6GQc5CD5oS/UEarYCVQPmKADfEQw6PJso68xIvicStcqiCRoNXZHc3ZtAIXJFQ+Qg==,iv:jALy1Z41hU9fmcrzAn41YC4DJp7beDqcqgdhbekyrmM=,tag:QvcXSpLLcJdGq5filIp32w==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -26,8 +27,8 @@ sops:
             QjBmYlNYWlFoWHd0ZFJkWE0xMkpvZzQKJwKap35S2pWGNOtBHe931dRqAQAczbWv
             /BUEtl900F8YLQCB1/myV0Dk5X9XDlww1yrzw/La3gXANY93Ndu3MA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-30T11:23:54Z"
-    mac: ENC[AES256_GCM,data:YG1Te+quE4eFadTJPyHPpJhVbs24bKtGCNS6VNvXK2fwUosd7GngprCIAfCKZ2Jzexjj+71zsfY72n/io952vK4bKoWDzFwE3cr1VJ0QQQ+BEoZjFJYEk4GOrmoEVzfIBqDEFpbOsA7VSvEawRrSeL2RqjHkaF/CNJWZfuH3tD8=,iv:M+t9Qn/Gl4oZwoSX72XeStPpVG3wAX7OKsk3vrJ9wto=,tag:/Tpy/92lUqLMqgIVkpBaFw==,type:str]
+    lastmodified: "2023-09-21T17:45:45Z"
+    mac: ENC[AES256_GCM,data:2VqM2IhWOCAAZPUBOv+/kiKCW5kgE2w3qXz9OeeKusUTVwNUj0+YAAx3tN0wsW3EsnExMJVcN3WTeRLCrR095/sLg7YaHsqIbo3YQDvx+HT/lvK1wj2vrTCtKmsDfwifub3rpaCA01i+A+qoVsxUmSXe9HWJeWIK9DQEt5Rhxts=,iv:ClfjOLlExQgkKDTpyH1K6/cxc2QfjW5UmDEcXqKgx24=,tag:rf2zroaE9JY7yMkFhvUSWg==,type:str]
     pgp:
         - created_at: "2023-07-23T14:01:56Z"
           enc: |-

--- a/secrets/hamilton/secrets.yaml
+++ b/secrets/hamilton/secrets.yaml
@@ -3,6 +3,7 @@ synapse:
     signing_key: ENC[AES256_GCM,data:WLdNVbGn772vuO9avavFvaHDlq5F1Pl2oxPlkIQC/pK9Q9GmFA2oxUy2QUPdrTfhlL6gJkjwO1JOiA==,iv:IcUQqTeJkASHTa++gXcWBzRP86Em4gm/1N/leMtFvRc=,tag:1zHAh64W/PDWa6BvhowS6w==,type:str]
     registration_shared_secret: ENC[AES256_GCM,data:3mcyn8+8bfRQTJf8a6CwfO/v10W1PvM3D6POq52BV49N1KVBSs27aGq6YZFzR0H9vF5qUGXGRzk+zdNk+GK0Lw==,iv:54ZI2SGGXOQstRU0C89sJlWluC0XnxNLqrjt/ad0MzQ=,tag:gD9h+nIOz049GlaRjgX5Aw==,type:str]
     secret_config: ENC[AES256_GCM,data:2NYKCQxZn2S5HP6h01epylIryfFVdPdm8Mew7b3eDnfrCmJcIS//OGlYaUM76Q574V5LHg86CXDBM1pgl38oxjT7MM1GMYXiYL7ancKUivUnvfcRBYi1ZF+oCJMEwmnx6FuElU3qQ82NnJgv1rSP9mJTkGt+02LTTZR3f/UdvBohmDUYk9jhzRhdX/I9wFR1JV8Dk1PcQ4ysLrCfL0lKvvGdBE3E2C5eRrFSjWAn+ezFYP23KfyNtpDHuKW7TEzlrpZrS1yPsQ9D3tt6K1bypuJX+7zpMpXP443dxs/ZAalL2yyodQysJ3/Sb5kQQXWudEnsXP72Biw26tUVgX6o8iZ9yJEmuZDhAk3PGSmuBeohYnxk8fKIkieIDTM14GEPvEaI,iv:Xemjx/o4v9QlbbI/ZLFnT9F14xTlJ0zDP4hnVvho3wc=,tag:PoE0dVAoU2twuWUqNSUPmg==,type:str]
+sliding-sync-env: ENC[AES256_GCM,data:5IMVu7iD7kPSD+VyoUWSti4uOSRcEFOrNL/9/4coavu+EPUZ0lMtGkcp7Tu+vJ+Wk8dTTupUs+wiTgAANRhtRI1ZKdHGjX4Betrz7dE6RA==,iv:9Mnzq/q1huodpjFsyXcRPvJwUD1qbOAtHk44+A4Sk20=,tag:a11lvEdOpmlNiG2TQ90LvQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -18,8 +19,8 @@ sops:
             aWQ2QW05a1lrbTZZci9VMldpVzNCZFkKCJwEd5TkZaIb2M1E149/NEUB1E5E8gLu
             YSDnb7eKfx8auWCEVCMiHx6POdpVvwxKnxUWHEnUBIMHhx+Y1MSclg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-31T18:55:28Z"
-    mac: ENC[AES256_GCM,data:Jfqd39+c22Zaib+98DgSku612aU6vhmccurPtV7nQ59dg8/C4vDQ13lfxljzlk8Xe9Lc56qfvhjpdGpDuGH1EB6OFoOvdYRWvn+GofCMRV/ss+BY4LEStMH3cWBerJSC9aUu7ULqqGuzMzfWbXOBVtR5OhqVcD6SRvMufbwoGa0=,iv:FqlSyXQIKPDC3qnsT9ljB2L2ZjRNDelr5RhIUDLW738=,tag:l5qU7y6znrA1p1GB1sQ3MQ==,type:str]
+    lastmodified: "2023-09-21T18:33:11Z"
+    mac: ENC[AES256_GCM,data:3TdjBvZ1OWrcAQ5ImNQXzb7LfyGRAYRpaA6MiL7mRYFYdNKlmG0CpuFSfhXl3sRWOrnqhZ6X4zw9zCuXx8yt0cP/xDngKZm3C/cDhaOro56UTyWjLjghBp9pLNT005TEJVtt09eoZ+2KaP3WUMCs2+crUBYGYWCCYmik69J7BBQ=,iv:Jx1BhLbLTdJJXDL662qU0qNIjyqWVuNJR3WWtRuIzJM=,tag:vAap+F4OVERIqgRZ6FqL+Q==,type:str]
     pgp:
         - created_at: "2023-08-12T09:39:58Z"
           enc: |-

--- a/services/website.nix
+++ b/services/website.nix
@@ -8,6 +8,7 @@
 let
   matrixWellKnown = {
     client."m.homeserver".base_url = "https://matrix.${baseDomain}/";
+    client."org.matrix.msc3575.proxy".url = "https://sync.matrix.${baseDomain}";
     server."m.server" = "matrix.${baseDomain}:443";
   };
   toJSONFile = name: value: pkgs.writeText name (builtins.toJSON value);


### PR DESCRIPTION
This should reduce the traffic between servers server and client significantly. Tho currently only Element X supports sliding sync, but it [doesn't support SSO login](https://github.com/vector-im/element-x-android/issues/954). But still, having this enabled seems like a good idea for going forward because of the possible future performance improvements.