### PR TITLE
nginx: don't log 404s

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -57,6 +57,7 @@
   # That way we can't forget to disable the access logs for each individual website
   services.nginx.appendHttpConfig = ''
     access_log off;
+    log_not_found off;
   '';
   security.acme = {
     acceptTerms = true;


### PR DESCRIPTION
Currently this is creating quite some log entries which makes debugging harder.