### PR TITLE
Flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692954414,
-        "narHash": "sha256-rl1g3aGG0Nlmae7DCGqvOe+yQAcqTGUxehcMAk6usWQ=",
+        "lastModified": 1708021734,
+        "narHash": "sha256-ujfb6a+X8ZDOMyH2W9t37zjOXbg6uZieMG6XjHRoS68=",
         "ref": "main",
-        "rev": "1594009c5040acd2d0c6b8700ca2cc64808041c4",
-        "revCount": 23,
+        "rev": "47281675af48d204db161add5c4f4b1c93a71425",
+        "revCount": 24,
         "type": "git",
         "url": "https://cyberchaos.dev/e1mo/freescout-nix-flake"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700794826,
-        "narHash": "sha256-RyJTnTNKhO0yqRpDISk03I/4A67/dp96YRxc86YOPgU=",
+        "lastModified": 1707956935,
+        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8",
+        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
         "type": "github"
       },
       "original": {
@@ -59,16 +59,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1700905716,
-        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
+        "lastModified": 1707603439,
+        "narHash": "sha256-LodBVZ3+ehJP2azM5oj+JrhfNAAzmTJ/OwAIOn0RfZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
+        "rev": "d8cd80616c8800feec0cab64331d7c3d5a1a6d98",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.05",
+        "ref": "release-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -89,11 +89,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1700967639,
-        "narHash": "sha256-uuUwD/O1QcVk+TWPZFwl4ioUkC8iACj0jEXSyE/wGPI=",
+        "lastModified": 1707842202,
+        "narHash": "sha256-3dTBbCzHJBinwhsisGJHW1HLBsLbj91+a5ZDXt7ttW0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4be58d802693d7def8622ff34d36714f8db40371",
+        "rev": "48afd3264ec52bee85231a7122612e2c5202fa74",
         "type": "github"
       },
       "original": {

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -28,24 +28,24 @@ final: prev:
     tag = final.stdenv.mkDerivation rec {
       name = "tag";
       pname = "dokuwiki-plugin-tag";
-      version = "2023-05-25";
+      version = "2023-10-17";
       src = final.fetchFromGitHub {
         owner = "dokufreaks";
         repo = "plugin-tag";
         rev = version;
-        hash = "sha256-HipMbLK6LSdBfHGW03ekLp3Rvh2JQbAPyVIRRHug4GU=";
+        hash = "sha256-W6p+t2pdThypazx58UsmBvjXovRHage+TdDPrsidXJc=";
       };
       installPhase = "mkdir -p $out; cp -R * $out/";
     };
     pagelist = final.stdenv.mkDerivation rec {
       name = "pagelist";
       pname = "dokuwiki-plugin-pagelist";
-      version = "2022-09-28";
+      version = "2023-08-27";
       src = final.fetchFromGitHub {
         owner = "dokufreaks";
         repo = "plugin-pagelist";
         rev = version;
-        hash = "sha256-IzedBYePVTS6jzWZeORpebsZiRgrnP+57t9mstQWnMQ=";
+        hash = "sha256-EHOpghE6ou1sdlGj6zIzRGAVCcwADteQeBW8adwBHpo=";
       };
       installPhase = "mkdir -p $out; cp -R * $out/";
     };
@@ -64,12 +64,12 @@ final: prev:
     nspages = final.stdenv.mkDerivation {
       name = "nspages";
       pname = "dokuwiki-plugin-nspages";
-      version = "2023-05-29";
+      version = "2024-01-04";
       src = final.fetchFromGitHub {
         owner = "gturri";
         repo = "nspages";
-        rev = "8763b40b3e9c79042055135e7c157aeaed5c078b";
-        hash = "sha256-Fa8gtImR8tP8Vnhys9rZdtxl8Ii8cfrXZsTFNC0sD3w=";
+        rev = "035c029bf43ef7f6418dd651bbdd23f347fe4ec0";
+        hash = "sha256-n5bOM7J4IFGKTYcicdXNtnjTWAAbjIvxWJWAMezbsDU=";
       };
       installPhase = "mkdir -p $out; cp -R * $out/";
     };

--- a/services/hedgedoc.nix
+++ b/services/hedgedoc.nix
@@ -66,7 +66,7 @@ in {
     ensureDatabases = [ "hedgedoc" ];
     ensureUsers = [{
       name = "hedgedoc";
-      ensurePermissions."DATABASE hedgedoc" = "ALL PRIVILEGES";
+      ensureDBOwnership = true;
     }];
   };
 

--- a/services/vaultwarden.nix
+++ b/services/vaultwarden.nix
@@ -25,9 +25,7 @@ in {
     ensureDatabases = [ vwDbName ];
     ensureUsers = [{
       name = vwDbUser;
-      ensurePermissions = {
-        "DATABASE ${vwDbName}" = "ALL PRIVILEGES";
-      };
+      ensureDBOwnership = true;
     }];
   };
 


### PR DESCRIPTION
```shell
$ nix flake update
warning: updating lock file '/home/e1mo/Documents/chaos-jetzt/chaos-jetzt-nixfiles/flake.lock':
• Updated input 'flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
  → 'github:numtide/flake-utils/4022d587cbbfd70fe950c1e2083a02621806a725' (2023-12-04)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5a09cb4b393d58f9ed0d9ca1555016a8543c2ac8' (2023-11-24)
  → 'github:NixOS/nixpkgs/46ae0210ce163b3cba6c7da08840c1d63de9c701' (2024-01-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/4be58d802693d7def8622ff34d36714f8db40371' (2023-11-26)
  → 'github:Mic92/sops-nix/f5fbcc0f50e7fc60c4f806fa7a09abccf0826d8a' (2024-01-07)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/dfb95385d21475da10b63da74ae96d89ab352431' (2023-11-25)
  → 'github:NixOS/nixpkgs/70bdadeb94ffc8806c0570eb5c2695ad29f0e421' (2024-01-03)
```