### PR TITLE
services/pretix: init

### DIFF
--- a/hosts/goldberg/configuration.nix
+++ b/hosts/goldberg/configuration.nix
@@ -10,6 +10,7 @@
     ../../services/dokuwiki.nix
     ../../services/freescout.nix
     ../../services/hedgedoc.nix
+    ../../services/pretix.nix
   ];
 
   system.stateVersion = "23.05";

--- a/hosts/shirley/configuration.nix
+++ b/hosts/shirley/configuration.nix
@@ -9,6 +9,7 @@
     ../../services/dokuwiki.nix
     ../../services/freescout.nix
     ../../services/hedgedoc.nix
+    ../../services/pretix.nix
   ];
 
   system.stateVersion = "23.05";

--- a/secrets/goldberg/secrets.yaml
+++ b/secrets/goldberg/secrets.yaml
@@ -11,6 +11,7 @@ dokuwiki:
 vaultwarden:
     env: ENC[AES256_GCM,data:mDqHHAjisl0din/q67+zH7NMKLXld9qC0Si6ZREhRStXr6HEFD/QwaGLN86AvUI7sHNf9l4nrgKOht7uXNJrkjuidGsFEEJWkuUOjBRnrtipNKV2YK7giPQXEhH7wTdGeaqxqi4sk90Oq/FoKi2vPkFyNWGOQ5vOXkKKXjjHnbyKIQkIRWya2Dy6IN0CXU8UK0OiQXY3kgEFOyJoqt4sx/HOScHNKkaLb8U+0rpfzxSVyP3oY4o/DFkE51bnd/CNKg3ZK4Ynp/5m7Rs=,iv:aWpDXSp6Ds7cfdw/vfM3I5wcHz0MytnhpIIWEa24LBE=,tag:5YZKo4ZCT57gji8iyBMAiQ==,type:str]
 hedgedoc_env: ENC[AES256_GCM,data:VHIzmq7P1pqS72HbRXRT3k7n6vyPkzkQFJdveseCAHnzdXlEF0lHr+Up7J6XhfhtQXO3ogV2jkGZpOMY0OuEvhLf2yGkBj3W0ZtG7Kx6Rdcbb5rG7Z6Vb1vpL/aT88QFd3VX23M+FPFyWeYKGOvGRuCela+mUX7jDs2W4jOrYOtEGe3+V08DcvtcCvE2L1NqeDQ=,iv:011/ZRdQlkFQ2TZpzQhfRf/OTawnHFQDockLGlOrkmc=,tag:Y66RIBtyjl5VSo23GU4sNg==,type:str]
+pretix_env: ENC[AES256_GCM,data:Cu3S3j49P0IVZMKfzuUBdPVl4YTDUybmVKasGCaqrcyWFKbRrd1XK9NmZ+iYHemuJ7A6F+I1qrnn7GdwayOQr0MCAIpoIuDjiYex1wi3WPkx48Dxk9YInoD6JGzmYQE64Qe08rlH1gt3nBXGKkUQ5D4razNokO1F4pYQxthsTvP3s5+zOD5Z3H6/wy30e5Ihtp3KMiiJ5OJzBUelmA2YN5Q/l4TAR/pTk0R5557TdAmqUuMWzxovCl4cXY8xP6Nlnc9X3Hg7YdfTOTAVLak5aMOi2kZFB79CxF8QBjZzwS1EuyFImyWohP53Yb/SxdnsgDNQQajxfQy/8Z4Bg1T7k2hRZ5LBuITwu15wu5V3h+VPTgZMDi1PeQhN8InZF8nNenpdw+4FRNinR7qIVf31SsCbAOXs2CU3KEi8KfEc7MEsvSG2tNOoy5zX/2H6EKvHJZED+mHcnvffAjTIkvVLvGw=,iv:NdCtoXtL0JtmzrheW6tbYd6XwyfH/DVqL9sZBPCmnws=,tag:/7ts5E1Pc5mF5YpWSGgorw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -26,8 +27,8 @@ sops:
             QjBmYlNYWlFoWHd0ZFJkWE0xMkpvZzQKJwKap35S2pWGNOtBHe931dRqAQAczbWv
             /BUEtl900F8YLQCB1/myV0Dk5X9XDlww1yrzw/La3gXANY93Ndu3MA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-30T11:23:54Z"
-    mac: ENC[AES256_GCM,data:YG1Te+quE4eFadTJPyHPpJhVbs24bKtGCNS6VNvXK2fwUosd7GngprCIAfCKZ2Jzexjj+71zsfY72n/io952vK4bKoWDzFwE3cr1VJ0QQQ+BEoZjFJYEk4GOrmoEVzfIBqDEFpbOsA7VSvEawRrSeL2RqjHkaF/CNJWZfuH3tD8=,iv:M+t9Qn/Gl4oZwoSX72XeStPpVG3wAX7OKsk3vrJ9wto=,tag:/Tpy/92lUqLMqgIVkpBaFw==,type:str]
+    lastmodified: "2024-03-26T20:16:20Z"
+    mac: ENC[AES256_GCM,data:oZTkmmXtzBkCqsupBFm9wCqOJvsIQtxIUV+Igrib1i1dogsifUjQlIcPyJDFWVgIZ5Cshq5SzVw0BBhGnxoxw+NJd3nPy++nOy70Robm3vqbi5M/LDLH06VgcSYemLfJCBXVOfIiUe0n20D1DJ+zn3UbfRRNlXeVfZhfER2WG/0=,iv:O8KjqOJbDFWI3pgsRPmgFN+NGG9NNUgWJsaEkpq855w=,tag:C874JKbIrcQL5PQCiBTfZQ==,type:str]
     pgp:
         - created_at: "2023-07-23T14:01:56Z"
           enc: |-
@@ -73,4 +74,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 5D22C6EC4A6E52469819B56D5EBCCEF2F33F7661
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1

--- a/secrets/shirley/secrets.yaml
+++ b/secrets/shirley/secrets.yaml
@@ -7,6 +7,7 @@ synapse:
 vaultwarden:
     env: ENC[AES256_GCM,data:4zeSpiaJQ8v00EBHrS6IU/1KXCEP6EBpkMacW0mf3ygZxSfUL3oQ11sXOu24OOMnTpaZUPJ68rj1jSNgBoVQ7rLttpCHKy62ART2xi0PcSCpDCBLpBocPdpFydQzwFOrMAYpcS6SB/ijy2ZxvfzVQqykcqfLdwdZs3PCys15OSQT269FmFERT25pTW7d6zxE3eY2YhLf1Y+6MjYHffAEv8RqN35UWyAOh8dJU09lbEsUiBRwN3tNhQ0STOsShhxY/ogMZdAHQwvGjo0=,iv:yK9PBOURtOVBBPwuJSpARvb5eXUIhPypEbEYbX2PqRs=,tag:MG7fcBPMg9eMjtD5V+yjBw==,type:str]
 hedgedoc_env: ENC[AES256_GCM,data:M/UW8QjiiHU/YsSYsYnZbeA+SPAub53E1FAiSvRFTeQeR0d3+t0g0lfn9Wqcok541NjETs7LN4lCrYBR6cH4EqQ9581pj2Fi5KabypA/2DUNTaAjtCbA2RNM/M/1/ka5n8AFNgzXppb/yEQ2xqQfV7IN/d6ClJzfFi+3FoFa3wRwAajvkH+yP8rfTBkQFamQWTQ=,iv:6vOeJHkNnva92GCrhuIj3HtG6z50UBnxRGg97jv2/gk=,tag:eYN4q7/HL0BtPdYLlbaW+A==,type:str]
+pretix_env: ENC[AES256_GCM,data:S3CoZGgkorhPRUzgCfMK5DGS2/UKBvUGjI6dP5lJNOC0fUhLIXC5dkXBs0uiCmDEYe61/Yus8Phfd7HIVJJuYo4FqGGZUs0kH/iuYSh5yFuNDSTKhml4xBXGa1ClwzuixcYc5zYMW8TBtLNacewfV//xHBhyQbzvd7WBoO7DuQ6GuUn0GV6AEWyHYoIpLCucAUUd08wgIcw05NqkDS0B/TBgyo/BOu0IQznmmBFG0t3+b4pJiATOoCfmP3+orjLGPDVGGWWDobONf/nk/XFSm0lg50vVlQNH/H21ElSGBsHJGDvHGsniC0h1oeAk6bYsQbb5iBnmUr7s0bttPsecS+w7TInTkxiM7Cwwb6imFexgbvDOluEiQQSy3/+x7nZd1DagKi+BaxOc1Na5vhO00PMSSm91g5n66oHr5TPKwXSiDbjBYaTjvGVIFMwXB0SawVaqYEsWn6eMTNuF2idcIN0=,iv:xeLhtbs/9c4DjlhCjIoix9fh34JV/acbXZIS7ZZ+0ao=,tag:wx+P50FqdKysXSDEfW2fyA==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -22,8 +23,8 @@ sops:
             Z3FXczZaSUVLY2lCcWJaQklXNHBzczAKQev4noy5ValCq65BhvXl1weY2QNsTe6f
             f4SUmm5NGbTiGaghOLC1Cio3K8ibA0vszVyySNE1khkvcM7JewIXAQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-30T11:25:43Z"
-    mac: ENC[AES256_GCM,data:Yvd2DHOKJJr0hm/nt6nO8RgG4nMUtfBa5M1KPlQYjzul8UVNdX7WvgYwbMlERifiVVirAjCeB0DybvWBozpPcAhPcZ6+8AlUQg77wQt+PgqaVCXvFMBeGFqPNaCi1JPVDjKvAEC/A+mvUDL52JH0c2PCoRCl/W1WXq7TfXRjzis=,iv:k930uOJRCxddz86vCu16SiWHZXSiLD5htVnGd73aIZk=,tag:ouMgLZqZ/e35P1we1mCsVw==,type:str]
+    lastmodified: "2024-03-26T21:40:35Z"
+    mac: ENC[AES256_GCM,data:lh0XwUFBAx06d9OKwHIMSz2iXfHjgakoXWJdppAGcl1dgduO6V1FD9reLANztnpn0W+HLNLz1wNc+Dd6dcrw+sHV4DeiRAeMQV4ZfcC4jHcnS3EebrGNdygtbUUlall24tqcIIo0AzUspRrS+xjYVKtUq2LlFcsWVD5eOY0yo9c=,iv:JmR/RwcKDt2VS7Y2arf3Za3QPK7dIboekcaG/Lut7rQ=,tag:noFQYXa66iwCGkwLt47PYw==,type:str]
     pgp:
         - created_at: "2023-07-23T14:01:46Z"
           enc: |-
@@ -69,4 +70,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 5D22C6EC4A6E52469819B56D5EBCCEF2F33F7661
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1

--- a/services/pretix.nix
+++ b/services/pretix.nix
@@ -1,4 +1,8 @@
-{ baseDomain, isDev, config, ... }:
+{ baseDomain
+, isDev
+, config
+, lib
+, ... }:
 
 let
   domain = "pretix.${baseDomain}";
@@ -32,7 +36,7 @@ in {
         user = "pretix";
       };
       mail = {
-        from = "pretix@chaos.jetzt";
+        from = "pretix${lib.optionalString isDev "-dev"}@chaos.jetzt";
         # environmentFile contains user, password, host, port, tls and ssl options
         admins = "administration@chaos.jetzt";
       };

--- a/services/pretix.nix
+++ b/services/pretix.nix
@@ -1,0 +1,65 @@
+{ baseDomain, isDev, config, ... }:
+
+let
+  domain = "pretix.${baseDomain}";
+in {
+  sops.secrets.pretix_env = {};
+
+  services.pretix = {
+    enable = true;
+    environmentFile = config.sops.secrets.pretix_env.path;
+    settings = {
+      pretix = {
+        instance_name = domain;
+        url = "https://${domain}";
+        currency = "EUR";
+        loglevel = if isDev then "INFO" else "WARNING";
+        plugins_default = "pretix.plugins.sendmail,pretix.plugins.statistics,pretix.plugins.ticketoutputpdf";
+        plugins_exclude = "pretix.plugins.paypal,pretix.plugins.paypal2,pretix.plugins.stripe,pretix.plugins.banktransfer";
+        audit_comments = true;
+        obligatory_2fa = true;
+        trust_x_forwarded_for = true;
+        trust_x_forwarded_proto = true;
+        trust_x_forwarded_host = true;
+      };
+      locale = {
+        default = "de-informal";
+        timezone = "Europe/Berlin";
+      };
+      database = {
+        backend = "postgresql";
+        name = "pretix";
+        user = "pretix";
+      };
+      mail = {
+        from = "pretix@chaos.jetzt";
+        # environmentFile contains user, password, host, port, tls and ssl options
+        admins = "administration@chaos.jetzt";
+      };
+      django = {
+        # PRETIX_DJANGO_SECRET contained in environmentFile
+        debug = false;
+      };
+      languages = {
+        enabled = "en,de-informal";
+      };
+    };
+
+    database.createLocally = true;
+    nginx = {
+      inherit domain;
+      enable = true;
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    virtualHosts."${domain}" = {
+      serverAliases = [ "tickets.${baseDomain}" ];
+      enableACME = true;
+      forceSSL = true;
+      locations."/".recommendedProxySettings = true;
+      locations."/jetzt5".return = "307 https://tickets.chaostreff-flensburg.de/chaos.jetzt/jetzt5";
+    };
+  };
+}

--- a/services/website.nix
+++ b/services/website.nix
@@ -64,12 +64,6 @@ in {
         "/.well-known/matrix/".alias =  matrixWellKnownDir + "/";
       };
     };
-
-    virtualHosts."tickets.${baseDomain}" = {
-      enableACME = true;
-      forceSSL = true;
-      locations."/".return = "307 https://tickets.chaostreff-flensburg.de/chaos.jetzt$request_uri";
-    };
   };
 
   users.users."web-deploy" = {


### PR DESCRIPTION
Will be running under `pretix.{dev.,}chaos.jetzt` and be pre-configured to allow for serving the chaos.jetzt organisation under `tickets.{dev.,}chaos.jetzt`.

To keep currently running sales, `tickets.chaos.jetzt/jetzt5` will continue redirecting to tickets.chaostreff-flensburg.de.

Close #37 as implemented.

Somewhat depends on #36 being merged.