### PR TITLE
Deploy MatrixJoinLink

### DIFF
--- a/modules/matrixjoinlink.nix
+++ b/modules/matrixjoinlink.nix
@@ -1,0 +1,120 @@
+{ config
+, pkgs
+, lib
+, ... }:
+
+with lib;
+
+let
+  cfg = config.cj.matrixjoinlink;
+  json = pkgs.formats.json {};
+  hash = builtins.hashString "sha512";
+  settings = cfg.settings // {
+    password = "SECRET_${hash cfg.password_file}";
+    encryptionKey = "SECRET_${hash cfg.encryptionKey_file}";
+  };
+  configUnsubstituted = json.generate "config.json" settings;
+  setupSecrets = pkgs.writeShellScript "setup-secrets" ''
+    set -o errexit -o pipefail -o nounset -o errtrace
+    shopt -s inherit_errexit
+    umask u=rw,g=,o=
+    cp ${configUnsubstituted} $CONFIG_PATH
+    chmod u+w $CONFIG_PATH
+    ${getExe pkgs.replace-secret} "SECRET_${hash cfg.password_file}" "''${CREDENTIALS_DIRECTORY}/password" "''${CONFIG_PATH}"
+    ${getExe pkgs.replace-secret} "SECRET_${hash cfg.encryptionKey_file}" "''${CREDENTIALS_DIRECTORY}/encryptionKey" "''${CONFIG_PATH}"
+  '';
+in {
+  options.cj.matrixjoinlink = {
+    enable = mkEnableOption "MatrixJoinLink bot";
+    package = mkPackageOption pkgs "matrixjoinlink" {};
+
+    password_file = mkOption {
+      type = types.path;
+      description = "Path to the password of the bot's account";
+      example = "/run/secrets/matrixjoinlink/password";
+    };
+
+    encryptionKey_file = mkOption {
+      type = types.path;
+      description = "Path to a symmetric key that will be used to encrypt the event content for the bot";
+      example = "/run/secrets/matrixjoinlink/encryptionkey";
+    };
+
+    settings = {
+      prefix = mkOption {
+        type = types.str;
+        default = "join";
+        description = "The command prefix the bot listens to";
+      };
+
+      baseUrl = mkOption {
+        type = types.str;
+        description = "The base url of the matrix server the bot shall use";
+        example = literalExpression "config.services.matrix-synapse.settings.public_baseurl";
+      };
+
+      username = mkOption {
+        type = types.str;
+        description = "The username of the bot's account";
+      };
+
+      dataDirectory = mkOption {
+        type = types.path;
+        description = "The path to the databases and media folder";
+        default = "/var/lib/matrixjoinlink/data";
+      };
+
+      admins = mkOption {
+        type = with types; listOf str;
+        description = "The matrix ids of the admins";
+        example = literalExpression "[ \"@user:invalid.domain\" ]";
+      };
+
+      users = mkOption {
+        type = with types; listOf str;
+        description = "The matrix ids of the authorized users or servers";
+        example = literalExpression "[ \":invalid.domain\" \"@other-user:another-invalid.domain\" ]";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.matrixjoinlink = rec {
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      path = [
+        cfg.package
+        pkgs.replace-secret
+      ];
+
+      environment.CONFIG_PATH = "%t/${serviceConfig.RuntimeDirectory}/config.json";
+
+      serviceConfig = {
+        DynamicUser = true;
+        User = "matrixjoinlink";
+        RuntimeDirectory = "matrixjoinlink";
+        StateDirectory = "matrixjoinlink";
+        StateDirectoryMode = "0700";
+
+        Restart = "always";
+        RestartSec = "10s";
+        RestartSteps = 3;
+        RestartMaxDelaySec = "1m";
+
+        LoadCredential = [
+          "password:${cfg.password_file}"
+          "encryptionKey:${cfg.encryptionKey_file}"
+        ];
+        ExecStartPre = setupSecrets;
+        ExecStart = getExe cfg.package;
+      };
+
+      unitConfig = {
+        StartLimitIntervalSec = "5m";
+        StartLimitBurst = 5;
+      };
+
+    };
+  };
+}

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -183,4 +183,6 @@ final: prev:
         ];
       };
   })];
+
+  matrixjoinlink = final.callPackage ./matrixjoinlink {};
 }

--- a/packages/matrixjoinlink/default.nix
+++ b/packages/matrixjoinlink/default.nix
@@ -1,0 +1,33 @@
+{ lib, fetchpatch, fetchFromGitHub, jre, makeWrapper, maven }:
+
+maven.buildMavenPackage rec {
+  pname = "matrixjoinlink";
+  version = "0.26.0";
+
+  src = fetchFromGitHub {
+    owner = "dfuchss";
+    repo = "MatrixJoinLink";
+    rev = "v${version}";
+    hash = "sha256-HyN4QTyaplc7WDScEH8Xq78IfChpkhjuSdZGrU9ANHI=";
+  };
+
+  mvnHash = "sha256-mzZX9DToZF50lhFGJJV93GGmP2hzIh7dOyHfQKikSZU=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/share/${pname}
+    install -Dm644 target/matrixjoinlink-${version}.jar $out/share/${pname}/${pname}.jar
+    install -Dm644 target/matrixjoinlink-${version}-jar-with-dependencies.jar $out/share/${pname}/${pname}-with-dependencies.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/${pname} \
+      --add-flags "-jar $out/share/${pname}/${pname}-with-dependencies.jar"
+  '';
+
+  meta = with lib; {
+    description = "This bot allows the creation of join links to non-public rooms in matrix.";
+    homepage = "https://fuchss.org/projects/matrix/joinlink/";
+    license = licenses.gpl3;
+    mainProgram = pname;
+  };
+}

--- a/secrets/goldberg/secrets.yaml
+++ b/secrets/goldberg/secrets.yaml
@@ -1,4 +1,7 @@
 coturn_static_auth_secret: ENC[AES256_GCM,data:OH5Qhl+hy1Afs2ARKOuXXSlMVy8LOr+q+hDeWMR8UKR1TKH5Cu4IkIp76T8Sep7Xih8OQyZOBScPaa9ftMUok7P0c5DNmV2xsQyVBy+dp0TokYBRqviFLouqZA+yOkm9nt7/Fx6qZ61cxh8PhnHrBHYR7R/7bxurPjRbXApKw6wwE33lzdCJ1bcA1oASZzYLz61ii9Ema0BqaWNsbvG3np+b86bKFnIgI7JSas07nUIKFTZEDtY/XtIQkEfWvyb5DyisPVEdt0w12ceuHrjFXZFnL/uPOUYnmT6U5Mrd5OBk1HUr2GqQp7wtWtquTL0L4niXCXnmX5tQCk0nb1YBWQ==,iv:/36tKe9d+I1eGFNyZrNtlgnrcguDYG4XegcWZCAGhS4=,tag:dlBd2I3OnD1y+tNL0WhnoQ==,type:str]
+matrixjoinlink:
+    password: ENC[AES256_GCM,data:3vEy9ID+rZoMs3CHUo+etZf1NdlAPetmr6c9TpPcuYgpVxeqQqlqtTa+H32GOzxDkKH/bR0URoJmkTpKcuZ1aL1H+HjZEOYZS+xqXEJEz8s5ezliXlXawNVVZd9XGRecqqMOELOM0nDz03OIwrCD1Eya5CQ92CjW9srDs9yuL7c=,iv:VjaHtGacQiTcIkrEEyihGK/V53IvCmub4Rgx8QNbDA4=,tag:nPyd2TArRrOia/XTOnSLMA==,type:str]
+    encryptionKey: ENC[AES256_GCM,data:A5UGmW7l1xL0e4/FtiwfL1WnK0FW3ZB8UBPIzO85EeEkcE+/dXHSjn4RBBTRJDN3Rhrw3gulSwSX4lCnPxoCWKmNdsfc5Yc0U/je5kic5aqnXKkeSan7tRzGLO7sAu2KdjWzkbmNefl7TCdMDBMq7VMhZjytl3q72vSJVbnWgqg=,iv:4vcguDGs9rFlJYeJVqL7eGd2Vhpq0L60UmYldLlI+cM=,tag:r5wjvbm+OYaLuckyt3asdQ==,type:str]
 synapse:
     signing_key: ENC[AES256_GCM,data:/wXjsAY30plaYptGL3SvS4JyP+UWgX7nzvMlMPepbLG5qplq1Ieo5qNTAugWIhtP8z3DkZBnIgTpOg==,iv:WwPs9XHkoHS70b+2oNjxgDdYsDZrudk/U3UgpTpLD2k=,tag:INce/W/Nxbvxz89AvIG2cg==,type:str]
     registration_shared_secret: ENC[AES256_GCM,data:8mo0Dr06uGOZKDCAHo66VOsU/FC6Az1SjEJX2zLQRDEXQAI1DfjxscQO+m/EJZTAYZ2BgRyo0kCuD7bDpx/qMw==,iv:bV+VLsEwNYapYXcA33clf4CHmAvpmHrjSrWWGRR5nxg=,tag:GG+w1MU617UlTjIu5sC9WQ==,type:str]
@@ -28,8 +31,8 @@ sops:
             QjBmYlNYWlFoWHd0ZFJkWE0xMkpvZzQKJwKap35S2pWGNOtBHe931dRqAQAczbWv
             /BUEtl900F8YLQCB1/myV0Dk5X9XDlww1yrzw/La3gXANY93Ndu3MA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-22T11:22:16Z"
-    mac: ENC[AES256_GCM,data:qIhlYEES4oJxj1U17AYxE78nL2hkmPsE91cPa9OqQjaA7ENp0kUCjxv1VT+CIuqJqbvcOGT+FfqIVnMAjm76umejOEkPaE94mO0mKpuAN9B4NtrTLNK3pAWWzGHUjLTDw2x4kJQqGueKvCPREiWcqZPwg9UM1D1BywT+oRol67Y=,iv:2fmI0YarUXxFptKzzvNySDkhYG7Smi1RFfvuylqMrlY=,tag:dYwoEtt2ZFLg58JJnUTQuQ==,type:str]
+    lastmodified: "2024-07-02T19:18:43Z"
+    mac: ENC[AES256_GCM,data:Bugs6moLvc7x0VTKmUs+X8Tnw76WDHlRJrdVPDxxX+0VZwNfvpvKyLARovEpdr2MFE18ueEZ/TI4Sd2SLP6tkmn/m4JYpD9sPwqBPMpMcggyrsX2RM/B5ZFSysQLGJuT7VDwD7XRbQHoT7BKBW9rCaHyPGNzJ/vuoub/YhW5bgg=,iv:jV7HflHrm8tWVidE5SvdvtUoSEeU6nG+aOaSAAaP/q0=,tag:bxRTS4dIuux0jByP7owuAw==,type:str]
     pgp:
         - created_at: "2023-07-23T14:01:56Z"
           enc: |-

--- a/secrets/goldberg/secrets.yaml
+++ b/secrets/goldberg/secrets.yaml
@@ -1,4 +1,4 @@
-coturn_static_auth_secret: ENC[AES256_GCM,data:OH5Qhl+hy1Afs2ARKOuXXSlMVy8LOr+q+hDeWMR8UKR1TKH5Cu4IkIp76T8Sep7Xih8OQyZOBScPaa9ftMUok7P0c5DNmV2xsQyVBy+dp0TokYBRqviFLouqZA+yOkm9nt7/Fx6qZ61cxh8PhnHrBHYR7R/7bxurPjRbXApKw6wwE33lzdCJ1bcA1oASZzYLz61ii9Ema0BqaWNsbvG3np+b86bKFnIgI7JSas07nUIKFTZEDtY/XtIQkEfWvyb5DyisPVEdt0w12ceuHrjFXZFnL/uPOUYnmT6U5Mrd5OBk1HUr2GqQp7wtWtquTL0L4niXCXnmX5tQCk0nb1YBWQ==,iv:/36tKe9d+I1eGFNyZrNtlgnrcguDYG4XegcWZCAGhS4=,tag:dlBd2I3OnD1y+tNL0WhnoQ==,type:str]
+coturn_static_auth_secret: ENC[AES256_GCM,data:rUOGgEwOVg+vIS8JNrSXpiGWfsTMvwqQD5MdZe94np+/+Y1uNZ9KV6mL+6vMJiNKRdfqliHiApldG97AJ/cU41IjSexm1QtvKciJX916NB5KEkRQ1bcv5aHuOY9e+juFQx0fND3eeitwuLK+epax30TV6oOHh5N0vuarazXVIlOBpYQ+znSeT+SOHnOJgeEXRzvap/AQlWKRm53660L7XfPeVIVhRv4s4x5QWKXzEeE2/WwtiWnERIhLT0ypJfn7MX/KVhuIR2hlFXPFj1o6n8NX7vCtUfSQvZmoRe9TYXsmpTxHGeoBmoITuEA6Q1k9+9boesge52JxOdwyBTg8DA==,iv:Ku9mp7WjR6euPspdXyjOBBdUIH/eqACtRq2U+A8zWAA=,tag:qPhmC0q5G0V/Jl3rFSj+ow==,type:str]
 matrixjoinlink:
     password: ENC[AES256_GCM,data:3vEy9ID+rZoMs3CHUo+etZf1NdlAPetmr6c9TpPcuYgpVxeqQqlqtTa+H32GOzxDkKH/bR0URoJmkTpKcuZ1aL1H+HjZEOYZS+xqXEJEz8s5ezliXlXawNVVZd9XGRecqqMOELOM0nDz03OIwrCD1Eya5CQ92CjW9srDs9yuL7c=,iv:VjaHtGacQiTcIkrEEyihGK/V53IvCmub4Rgx8QNbDA4=,tag:nPyd2TArRrOia/XTOnSLMA==,type:str]
     encryptionKey: ENC[AES256_GCM,data:A5UGmW7l1xL0e4/FtiwfL1WnK0FW3ZB8UBPIzO85EeEkcE+/dXHSjn4RBBTRJDN3Rhrw3gulSwSX4lCnPxoCWKmNdsfc5Yc0U/je5kic5aqnXKkeSan7tRzGLO7sAu2KdjWzkbmNefl7TCdMDBMq7VMhZjytl3q72vSJVbnWgqg=,iv:4vcguDGs9rFlJYeJVqL7eGd2Vhpq0L60UmYldLlI+cM=,tag:r5wjvbm+OYaLuckyt3asdQ==,type:str]
@@ -31,8 +31,8 @@ sops:
             QjBmYlNYWlFoWHd0ZFJkWE0xMkpvZzQKJwKap35S2pWGNOtBHe931dRqAQAczbWv
             /BUEtl900F8YLQCB1/myV0Dk5X9XDlww1yrzw/La3gXANY93Ndu3MA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-07-02T19:18:43Z"
-    mac: ENC[AES256_GCM,data:Bugs6moLvc7x0VTKmUs+X8Tnw76WDHlRJrdVPDxxX+0VZwNfvpvKyLARovEpdr2MFE18ueEZ/TI4Sd2SLP6tkmn/m4JYpD9sPwqBPMpMcggyrsX2RM/B5ZFSysQLGJuT7VDwD7XRbQHoT7BKBW9rCaHyPGNzJ/vuoub/YhW5bgg=,iv:jV7HflHrm8tWVidE5SvdvtUoSEeU6nG+aOaSAAaP/q0=,tag:bxRTS4dIuux0jByP7owuAw==,type:str]
+    lastmodified: "2024-07-02T19:49:57Z"
+    mac: ENC[AES256_GCM,data:28L6nbZms7df9fvrcC5HdDl7fwHFlXDrW3JibwzlTARfi7p9goOUxpUUifXcrWU6dawWJS/b9CQyy9eUoT2XpqXFF3bkMK67to8IGJWTjkF2x2hEa+nl+OuXFCz5cqr/QsDtNPzEitDARA7+GNt8qtUoxiZ41oFmEx2rfQyEmj0=,iv:gUL8/7ZcKConZamz3kWTBZuYg+opn8LPueNfxPfzfi0=,tag:9hAPtZmZH+puf0o3WpwpDw==,type:str]
     pgp:
         - created_at: "2023-07-23T14:01:56Z"
           enc: |-

--- a/secrets/hamilton/secrets.yaml
+++ b/secrets/hamilton/secrets.yaml
@@ -3,6 +3,9 @@ synapse:
     signing_key: ENC[AES256_GCM,data:WLdNVbGn772vuO9avavFvaHDlq5F1Pl2oxPlkIQC/pK9Q9GmFA2oxUy2QUPdrTfhlL6gJkjwO1JOiA==,iv:IcUQqTeJkASHTa++gXcWBzRP86Em4gm/1N/leMtFvRc=,tag:1zHAh64W/PDWa6BvhowS6w==,type:str]
     registration_shared_secret: ENC[AES256_GCM,data:3mcyn8+8bfRQTJf8a6CwfO/v10W1PvM3D6POq52BV49N1KVBSs27aGq6YZFzR0H9vF5qUGXGRzk+zdNk+GK0Lw==,iv:54ZI2SGGXOQstRU0C89sJlWluC0XnxNLqrjt/ad0MzQ=,tag:gD9h+nIOz049GlaRjgX5Aw==,type:str]
     secret_config: ENC[AES256_GCM,data:2NYKCQxZn2S5HP6h01epylIryfFVdPdm8Mew7b3eDnfrCmJcIS//OGlYaUM76Q574V5LHg86CXDBM1pgl38oxjT7MM1GMYXiYL7ancKUivUnvfcRBYi1ZF+oCJMEwmnx6FuElU3qQ82NnJgv1rSP9mJTkGt+02LTTZR3f/UdvBohmDUYk9jhzRhdX/I9wFR1JV8Dk1PcQ4ysLrCfL0lKvvGdBE3E2C5eRrFSjWAn+ezFYP23KfyNtpDHuKW7TEzlrpZrS1yPsQ9D3tt6K1bypuJX+7zpMpXP443dxs/ZAalL2yyodQysJ3/Sb5kQQXWudEnsXP72Biw26tUVgX6o8iZ9yJEmuZDhAk3PGSmuBeohYnxk8fKIkieIDTM14GEPvEaI,iv:Xemjx/o4v9QlbbI/ZLFnT9F14xTlJ0zDP4hnVvho3wc=,tag:PoE0dVAoU2twuWUqNSUPmg==,type:str]
+matrixjoinlink:
+    password: ENC[AES256_GCM,data:PYQLlsoG6C9lM8uY8n1l0JZkAvGSZe+UuIrKyau2LfYjgXetN8fr3gJxG6NjGg5Mhuaac7NSQdpByXC9Bil+gWH/guHoF8hutyjuVVibhOqwS5TExUmiX0Fhszk7+9v9eiXewPDhU5iTbEUqm766L15cWGFlVSVqfDfetjrpk8M=,iv:Ian2tfWw2q+XJbb5kD4/W+RAIAlcEnCnXuDod+2vu98=,tag:rPXrMdvxU9UEOPl0CLOorw==,type:str]
+    encryptionKey: ENC[AES256_GCM,data:aCptyct/cKDiPfm3vCMGzBVG66Iajk4I3VSEbi7mCaTgqORqqsnmUHiXuIoZvcMpDqiiPnDkAOqJ/sZbibljRcFpXj9gxqFhJVBym9FuIictGaZwjrfvUC/YS20FkHL0NdS2hAX21yXrP7Qj8Jv4KjjF5/iw2KNXhj6uSC7IQHo=,iv:RqTCLi/XXCs5qiPMEFHdqE/3nSnGygu3WZnAWaeeb2A=,tag:3S6WgnjstKn4mG8NrqTiHQ==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -18,8 +21,8 @@ sops:
             aWQ2QW05a1lrbTZZci9VMldpVzNCZFkKCJwEd5TkZaIb2M1E149/NEUB1E5E8gLu
             YSDnb7eKfx8auWCEVCMiHx6POdpVvwxKnxUWHEnUBIMHhx+Y1MSclg==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2023-08-31T18:55:28Z"
-    mac: ENC[AES256_GCM,data:Jfqd39+c22Zaib+98DgSku612aU6vhmccurPtV7nQ59dg8/C4vDQ13lfxljzlk8Xe9Lc56qfvhjpdGpDuGH1EB6OFoOvdYRWvn+GofCMRV/ss+BY4LEStMH3cWBerJSC9aUu7ULqqGuzMzfWbXOBVtR5OhqVcD6SRvMufbwoGa0=,iv:FqlSyXQIKPDC3qnsT9ljB2L2ZjRNDelr5RhIUDLW738=,tag:l5qU7y6znrA1p1GB1sQ3MQ==,type:str]
+    lastmodified: "2024-07-02T19:35:56Z"
+    mac: ENC[AES256_GCM,data:xwtuGKnGjOSOE3G31xFVUkqIY0HfEkjDH3glPPmgD30K4mNy0U3oB9mZtkg+8f2/G2m2PxTNsciPM8rrojaEPkC2NPmR1qZzLOPcfRuAswoPuvVBHU+mMLGoCS5N83j2J0x9ZnC1da/Ee4hyzqSS+Tk6Nm78eWKOvgsTZjQ0FFg=,iv:rfT96SkUus0/AxgoQjParQmVVTM0kezfjV8ncnV8w8s=,tag:mnmTc+ThnL49gDOxbHu3XA==,type:str]
     pgp:
         - created_at: "2023-08-12T09:39:58Z"
           enc: |-
@@ -65,4 +68,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: 5D22C6EC4A6E52469819B56D5EBCCEF2F33F7661
     unencrypted_suffix: _unencrypted
-    version: 3.7.3
+    version: 3.8.1

--- a/services/matrix/default.nix
+++ b/services/matrix/default.nix
@@ -149,7 +149,7 @@ in {
         }];
         user_mapping_provider.module = "matrix_synapse_saml_mapper.SamlMappingProvider";
       };
-      password_config.enabled = true;
+      password_config.enabled = "only_for_reauth";
       media_retention = {
         # Since clearing remote media does the trick for now when it comes to purging old media
         # keeping local media for virtually unlimited time (for now, may change in the future).

--- a/services/matrix/default.nix
+++ b/services/matrix/default.nix
@@ -149,7 +149,7 @@ in {
         }];
         user_mapping_provider.module = "matrix_synapse_saml_mapper.SamlMappingProvider";
       };
-      password_config.enabled = "only_for_reauth";
+      password_config.enabled = true;
       media_retention = {
         # Since clearing remote media does the trick for now when it comes to purging old media
         # keeping local media for virtually unlimited time (for now, may change in the future).

--- a/services/matrix/default.nix
+++ b/services/matrix/default.nix
@@ -15,6 +15,10 @@ in {
     "synapse/registration_shared_secret".owner = "matrix-synapse";
   };
 
+  imports = [
+    ./matrixjoinlink.nix
+  ];
+
   services.nginx = {
     recommendedProxySettings = true;
     virtualHosts = {
@@ -145,7 +149,7 @@ in {
         }];
         user_mapping_provider.module = "matrix_synapse_saml_mapper.SamlMappingProvider";
       };
-      password_config.enabled = false;
+      password_config.enabled = "only_for_reauth";
       media_retention = {
         # Since clearing remote media does the trick for now when it comes to purging old media
         # keeping local media for virtually unlimited time (for now, may change in the future).

--- a/services/matrix/matrixjoinlink.nix
+++ b/services/matrix/matrixjoinlink.nix
@@ -1,0 +1,35 @@
+{ config
+, baseDomain
+, ... }:
+
+{
+  imports = [
+    ../../modules/matrixjoinlink.nix
+  ];
+
+  sops.secrets = {
+    "matrixjoinlink/password" = {};
+    "matrixjoinlink/encryptionKey" = {};
+  };
+
+  cj.matrixjoinlink = {
+    enable = true;
+    password_file = config.sops.secrets."matrixjoinlink/password".path;
+    encryptionKey_file = config.sops.secrets."matrixjoinlink/encryptionKey".path;
+
+    settings = {
+      prefix = "join";
+      baseUrl = config.services.matrix-synapse.settings.public_baseurl;
+      username = "joinlink_bot";
+      admins = [
+        "@e1mo:${baseDomain}"
+        "@ruru4143:gemeinsam.jetzt"
+        "@adb:adb.sh"
+        "@momme:${baseDomain}"
+      ];
+      users = [
+        ":${baseDomain}"
+      ];
+    };
+  };
+}


### PR DESCRIPTION
In the context of jetzt4 this was proposed as a solution to be able to invite to non-public rooms in the chaos.jetzt space via links.

Deployment needs the following:

1. Create a user using `matrix-synapse-register_new_matrix_user`:
   - `register_new_matrix_user --no-admin -u joinlink_bot -p ... -c <path to config>` (must be the binary in the package because it fails to load multiple configs)
2. Place the credentials in the secrets
3. Deploy with `services.matrix-synapse.settings.password_config.enabled = true;`
   - Required because `only_for_reauth` requires that users did authenticate previously (aka. with `enabled = true;`) with their password.
4. Deploy with `[...].enabled = "only_for_reauth";`
5. Invite to the required rooms.